### PR TITLE
bumps dug req to new build off of dug's trapi-1.0-revamp branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ redisgraph==2.1.5
 redisgraph-bulk-loader==0.9.5
 requests<2.24.0
 PyYAML==5.3.1
-dug-test==1.0.9
+dug-test==1.0.10
 elasticsearch==7.11.0
 # Dug installs bmt=0.1.0, but roger need bmt=0.4.0
 git+git://github.com/biolink/biolink-model-toolkit@0.4.0#egg=bmt


### PR DESCRIPTION
New code changes live at https://github.com/helxplatform/dug/tree/trapi-1.0-revamp , the dug-test build is off of that. 
 