### PR TITLE
Adding Dug as a submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/
@@ -139,3 +138,9 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# IDE
+.idea
+
+# Python envs
+.python-version

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/dug"]
+	path = lib/dug
+	url = git@github.com:helxplatform/dug.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ redisgraph==2.1.5
 redisgraph-bulk-loader==0.9.5
 requests<2.24.0
 PyYAML==5.3.1
-dug-test==1.0.13
 elasticsearch==7.11.0
 # Dug installs bmt=0.1.0, but roger need bmt=0.4.0
 git+git://github.com/biolink/biolink-model-toolkit@0.4.0#egg=bmt


### PR DESCRIPTION
Both Dug and Roger are in active development. The current workflow of making development changes in Dug then pushing them to the dug-test PyPI package is time consuming. This change adds Dug as a submodule to Roger, so Roger devs can use code against the features in Dug that are under active development.

Devs should be able to run:
```shell
pip uninstall -y dug-test
git submodule init
git submodule update
pip install lib/dug. # or pip install -e lib/dug 
```

Make sure to familiarize yourself with git submodules and document any questions here