### PR TITLE
Fix/indexing concepts tweak

### DIFF
--- a/dags/dug_helpers/dug_utils.py
+++ b/dags/dug_helpers/dug_utils.py
@@ -201,7 +201,7 @@ class Dug:
                 "id": element.id,
                 "name": element.name,
                 "category": ["biolink:ClinicalModifier"],
-                "description": element.description
+                "description": element.description.replace("'", '`') # bulk loader parsing issue
             }
             if element.id not in written_nodes:
                 nodes.append(variable_node)

--- a/dags/dug_helpers/dug_utils.py
+++ b/dags/dug_helpers/dug_utils.py
@@ -558,6 +558,7 @@ class DugUtil():
             if files is None:
                 files = Util.dug_topmed_objects()
             parser_name = "TOPMedTag"
+            log.info(files)
             dug.annotate_files(parser_name=parser_name,
                                parsable_files=files)
             output_log = dug.log_stream.getvalue() if to_string else ''

--- a/dags/dug_helpers/dug_utils.py
+++ b/dags/dug_helpers/dug_utils.py
@@ -450,6 +450,11 @@ class Dug:
             concept.set_search_terms()
             concept.set_optional_terms()
             concept.clean()
+            identifier = concept.identifiers.get(concept_id)
+            if not concept.name:
+                concept.name = identifier.label or identifier.search_text[0] if len(identifier.search_text) else ''
+            if not concept.type:
+                concept.type = identifier.types[0]
             percent_complete = int((counter / total) * 100)
             if percent_complete % 10 == 0:
                 log.info(f"{percent_complete}%")

--- a/dags/dug_helpers/dug_utils.py
+++ b/dags/dug_helpers/dug_utils.py
@@ -450,11 +450,6 @@ class Dug:
             concept.set_search_terms()
             concept.set_optional_terms()
             concept.clean()
-            identifier = concept.identifiers.get(concept_id)
-            if not concept.name:
-                concept.name = identifier.label or identifier.search_text[0] if len(identifier.search_text) else ''
-            if not concept.type:
-                concept.type = identifier.types[0]
             percent_complete = int((counter / total) * 100)
             if percent_complete % 10 == 0:
                 log.info(f"{percent_complete}%")

--- a/dags/dug_helpers/dug_utils.py
+++ b/dags/dug_helpers/dug_utils.py
@@ -276,7 +276,7 @@ class Dug:
             nodes.append({
                 "id": tag_id,
                 "name": tag.name,
-                "description": tag.description,
+                "description": tag.description.replace("'", "`"),
                 "category": ["biolink:InformationContentEntity"]
             })
             """ Link ontology identifiers we've found for this tag via nlp. """

--- a/dags/roger/Config.py
+++ b/dags/roger/Config.py
@@ -68,7 +68,7 @@ class AnnotationConfig(DictLike):
     annotator: str = "https://api.monarchinitiative.org/api/nlp/annotate/entities?min_length=4&longest_only=false&include_abbreviation=false&include_acronym=false&include_numbers=false&content="
     normalizer: str = "https://nodenormalization-sri.renci.org/get_normalized_nodes?curie="
     synonym_service: str = "https://onto.renci.org/synonyms/"
-    ontology_metadata: str = "https://api.monarchinitiative.org/api/ontology/term/"
+    ontology_metadata: str = "https://api.monarchinitiative.org/api/bioentity/"
     preprocessor: dict = field(default_factory=lambda:
         {
             "debreviator": {

--- a/dags/roger/config.yaml
+++ b/dags/roger/config.yaml
@@ -11,7 +11,7 @@ logging:
 
 data_root: roger/data
 dug_data_root: dug_helpers/dug_data/
-base_data_uri: https://stars.renci.org/var/kgx_data/trapi-1.0/
+base_data_uri: https://stars.renci.org/var/kgx_data/v2.0/
 
 kgx:
   biolink_model_version: 1.5.0

--- a/dags/roger/config.yaml
+++ b/dags/roger/config.yaml
@@ -34,7 +34,7 @@ annotation:
   annotator: "https://api.monarchinitiative.org/api/nlp/annotate/entities?min_length=4&longest_only=false&include_abbreviation=false&include_acronym=false&include_numbers=false&content="
   normalizer: "https://nodenormalization-sri.renci.org/1.1/get_normalized_nodes?curie="
   synonym_service: "https://onto.renci.org/synonyms/"
-  ontology_metadata: "https://api.monarchinitiative.org/api/ontology/term/"
+  ontology_metadata: "https://api.monarchinitiative.org/api/bioentity/"
   preprocessor:
     debreviator:
       BMI: "body mass index"
@@ -54,8 +54,6 @@ indexing:
     "anat": ["disease", "anatomical_entity"]
     "chem_to_disease": ["chemical_substance", "disease"]
     "phen_to_anat": ["phenotypic_feature", "anatomical_entity"]
-    "anat_to_disease": ["anatomical_entity", "disease"]
-    "anat_to_pheno": ["anatomical_entity", "phenotypic_feature"]
   tranql_endpoint: "http://tranql:8081/tranql/query?dynamic_id_resolution=true&asynchronous=false"
 
 elasticsearch:

--- a/dags/roger/core.py
+++ b/dags/roger/core.py
@@ -131,7 +131,7 @@ class Util:
                 yaml.dump (obj, outfile)
         elif path.endswith (".json"):
             with open (path, "w") as stream:
-                stream.write(str(json.dumps (obj).decode('utf-8')))
+                stream.write(str(json.dumps (obj))).decode('utf-8')))
         elif path.endswith(".pickle"):
             with open (path, "wb") as stream:
                 pickle.dump(obj, file=stream)
@@ -242,7 +242,7 @@ class Util:
     @staticmethod
     def dug_topmed_path(name):
         """ Topmed source files"""
-        return Util.dug_input_files_path('topmed_data') / name
+        return Util.dug_input_files_path('topmed') / name
 
     @staticmethod
     def dug_topmed_objects():

--- a/dags/roger/core.py
+++ b/dags/roger/core.py
@@ -131,7 +131,7 @@ class Util:
                 yaml.dump (obj, outfile)
         elif path.endswith (".json"):
             with open (path, "w") as stream:
-                stream.write(str(json.dumps (obj))).decode('utf-8')))
+                stream.write(str(json.dumps (obj).decode('utf-8')))
         elif path.endswith(".pickle"):
             with open (path, "wb") as stream:
                 pickle.dump(obj, file=stream)

--- a/dags/roger/core.py
+++ b/dags/roger/core.py
@@ -246,7 +246,7 @@ class Util:
 
     @staticmethod
     def dug_topmed_objects():
-        topmed_file_pattern = Util.dug_topmed_path("topmed_*.csv")
+        topmed_file_pattern = str(Util.dug_topmed_path("topmed_*.csv"))
         return sorted(glob.glob(topmed_file_pattern))
 
     @staticmethod

--- a/dags/roger/core.py
+++ b/dags/roger/core.py
@@ -242,8 +242,7 @@ class Util:
     @staticmethod
     def dug_topmed_path(name):
         """ Topmed source files"""
-        home = os.path.dirname(os.path.abspath(__file__))
-        return os.path.join(home, "../..", "dug_helpers", "dug_data", "topmed_data", name)
+        return Util.dug_input_files_path('topmed_data') / name
 
     @staticmethod
     def dug_topmed_objects():

--- a/dags/roger/metadata.yaml
+++ b/dags/roger/metadata.yaml
@@ -17,6 +17,24 @@ versions:
   - uberongraph.json
   - viral-proteome.json
   version: v1.0
+- files:
+  - biolink.json
+  - ctd.json
+  - gtopdb.json
+  - hetio.json
+  - hgnc.json
+  - hmdb.json
+  - kegg.json
+  - mychem.json
+  - ontological-hierarchy.json
+  - panther.json
+  - foodb.json
+  - pharos.json
+  - intact.json
+  - human-goa.json
+  - uberongraph.json
+  - viral-proteome.json
+  version: v2.0
 - version: test
   files:
   - panther.json


### PR DESCRIPTION
* Adds replace for topmed kgx that replaces single quotes to backticks , due to an issue in bulk loading step where single quotes cause errors when parsing array values in bulk nodes csv files. 
* changes ontology helper url to what's used by dug currently
* Adds new set of kgx files to meta data. Not this requires chart deployment with version set to v2.0 and base_data url set to this new version (base_data_uri: https://stars.renci.org/var/kgx_data/v2.0/) 