### PR TITLE
Feature/redis lib updates

### DIFF
--- a/dags/roger/core.py
+++ b/dags/roger/core.py
@@ -1255,7 +1255,7 @@ class BulkLoad:
             edges_with_type = [ f"{x.replace(bulk_path_root, '').strip(os.path.sep).split('.')[0].replace('~', ':')} {x}"
                                for x in edges]
             args.extend(("-R " + " -R ".join(edges_with_type)).split())
-        args.extend([f'--max-buffer-size={64}'])
+        args.extend([f'--max-buffer-size={1}'])
         args.extend([f"--separator={self.separator}"])
         args.extend([f"--host={redisgraph['host']}"])
         args.extend([f"--port={redisgraph['port']}"])

--- a/dags/roger/core.py
+++ b/dags/roger/core.py
@@ -1255,7 +1255,6 @@ class BulkLoad:
             edges_with_type = [ f"{x.replace(bulk_path_root, '').strip(os.path.sep).split('.')[0].replace('~', ':')} {x}"
                                for x in edges]
             args.extend(("-R " + " -R ".join(edges_with_type)).split())
-        args.extend([f'--max-buffer-size={1}'])
         args.extend([f"--separator={self.separator}"])
         args.extend([f"--host={redisgraph['host']}"])
         args.extend([f"--port={redisgraph['port']}"])

--- a/dags/roger/core.py
+++ b/dags/roger/core.py
@@ -1255,7 +1255,7 @@ class BulkLoad:
             edges_with_type = [ f"{x.replace(bulk_path_root, '').strip(os.path.sep).split('.')[0].replace('~', ':')} {x}"
                                for x in edges]
             args.extend(("-R " + " -R ".join(edges_with_type)).split())
-        args.extend([f'--max-buffer-size={512}'])
+        args.extend([f'--max-buffer-size={64}'])
         args.extend([f"--separator={self.separator}"])
         args.extend([f"--host={redisgraph['host']}"])
         args.extend([f"--port={redisgraph['port']}"])

--- a/dags/roger/core.py
+++ b/dags/roger/core.py
@@ -1255,6 +1255,7 @@ class BulkLoad:
             edges_with_type = [ f"{x.replace(bulk_path_root, '').strip(os.path.sep).split('.')[0].replace('~', ':')} {x}"
                                for x in edges]
             args.extend(("-R " + " -R ".join(edges_with_type)).split())
+        args.extend([f'--max-buffer-size={512}'])
         args.extend([f"--separator={self.separator}"])
         args.extend([f"--host={redisgraph['host']}"])
         args.extend([f"--port={redisgraph['port']}"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ botocore==1.21.23
 flatten-dict
 psycopg2-binary==2.8.6
 redis==3.5.3
-redisgraph==2.1.5
-redisgraph-bulk-loader==0.9.5
+redisgraph==2.4.1
+redisgraph-bulk-loader
 requests<2.24.0
 pytest==6.2.2
 PyYAML==5.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ flatten-dict
 psycopg2-binary==2.8.6
 redis==3.5.3
 redisgraph==2.4.1
-redisgraph-bulk-loader
+redisgraph-bulk-loader==0.9.5
 requests<2.24.0
 pytest==6.2.2
 PyYAML==5.3.1


### PR DESCRIPTION
- Updates redisgraph version
- bulk loader version has version conflict with kgx (both depend on click, latest bulkload lib depends on a version incomatible)
- updates get node-* and edge-* to scan instead of keys