### PR TITLE
Feature/cde crawls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ USER airflow
 COPY requirements.txt requirements.txt
 # dependency resolution taking hours eventually failing,
 # @TODO fix click lib dependency
-RUN pip install --use-deprecated=legacy-resolver -r requirements.txt
+RUN pip install -r requirements.txt
 RUN pip uninstall -y elasticsearch-dsl
 RUN rm -f requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ RUN apt-get update && \
     apt-get install -y git gcc python3-dev nano vim
 USER airflow
 COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt
+# dependency resolution taking hours eventually failing,
+# @TODO fix click lib dependency
+RUN pip install --use-deprecated=legacy-resolver -r requirements.txt
 RUN pip uninstall -y elasticsearch-dsl
 RUN rm -f requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ rm_dirs:
 #install: Install application along with required packages to local environment
 install:
 	${PYTHON} -m pip install --upgrade pip
-	${PYTHON} -m pip install -r requirements.txt
+	${PYTHON} -m pip install --use-deprecated=legacy-resolver -r requirements.txt
 
 #test.lint: Run flake8 on the source code
 test.lint:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ rm_dirs:
 #install: Install application along with required packages to local environment
 install:
 	${PYTHON} -m pip install --upgrade pip
-	${PYTHON} -m pip install --use-deprecated=legacy-resolver -r requirements.txt
+	${PYTHON} -m pip install -r requirements.txt
 
 #test.lint: Run flake8 on the source code
 test.lint:

--- a/dags/dug_helpers/dug_utils.py
+++ b/dags/dug_helpers/dug_utils.py
@@ -430,9 +430,11 @@ class Dug:
         """
         crawl_dir = Util.dug_crawl_path('crawl_output')
         output_file_name = os.path.join(data_set_name, 'expanded_concepts.pickle')
+        extracted_dug_elements_file_name = os.path.join(data_set_name, 'extracted_graph_elements.pickle')
         output_file = Util.dug_expanded_concepts_path(output_file_name)
+        extracted_output_file = Util.dug_expanded_concepts_path(extracted_dug_elements_file_name)
         Path(crawl_dir).mkdir(parents=True, exist_ok=True)
-
+        extracted_dug_elements = []
         log.debug("Creating Dug Crawler object")
         crawler = Crawler(
             crawl_file="",
@@ -450,11 +452,13 @@ class Dug:
             crawler.expand_concept(concept)
             concept.set_search_terms()
             concept.set_optional_terms()
+            extracted_dug_elements += crawler.expand_to_dug_element(concept)
             concept.clean()
             percent_complete = int((counter / total) * 100)
             if percent_complete % 10 == 0:
                 log.info(f"{percent_complete}%")
         Util.write_object(obj=concepts, path=output_file)
+        Util.write_object(obj=extracted_dug_elements, path=extracted_output_file)
 
     def index_concepts(self, concepts):
         log.info("Indexing Concepts")
@@ -632,6 +636,16 @@ class DugUtil():
         with Dug(config, to_string=to_string) as dug:
             dug.clear_variables_index()
             elements_object_files = Util.dug_elements_objects()
+            for file in elements_object_files:
+                dug.index_elements(file)
+            output_log = dug.log_stream.getvalue() if to_string else ''
+        return output_log
+
+    @staticmethod
+    def index_extracted_elements(config=None, to_string=False):
+        with Dug(config, to_string=to_string) as dug:
+            dug.clear_variables_index()
+            elements_object_files = Util.dug_extracted_elements_objects()
             for file in elements_object_files:
                 dug.index_elements(file)
             output_log = dug.log_stream.getvalue() if to_string else ''

--- a/dags/index_dag.py
+++ b/dags/index_dag.py
@@ -1,5 +1,6 @@
 from airflow.models import DAG
 from airflow.operators.bash_operator import BashOperator
+from airflow.operators.dummy import DummyOperator
 
 from roger.dag_util import get_executor_config, default_args, create_python_task
 from dug_helpers.dug_utils import DugUtil
@@ -19,8 +20,14 @@ with DAG(
     validate_index_variables = create_python_task(dag,"ValidateIndexVariables", DugUtil.validate_indexed_variables)
     crawl_tags = create_python_task(dag, "CrawlConcepts", DugUtil.crawl_tranql)
     index_concepts = create_python_task(dag, "IndexConcepts", DugUtil.index_concepts)
+    dummy_stepover = DummyOperator(
+        task_id="continue",
+    )
+    index_extracted_dug_elements = create_python_task(dag, "IndexExtractedElements", DugUtil.index_extracted_elements)
     validate_index_concepts = create_python_task(dag, "ValidateIndexConcepts", DugUtil.validate_indexed_concepts)
     finish = BashOperator (task_id='Finish', bash_command='echo finish')
     """ Build the DAG. """
     intro >> index_variables >> validate_index_variables >> finish
-    intro >>  crawl_tags >> index_concepts >> validate_index_concepts >> finish
+    intro >> crawl_tags >> index_concepts >> dummy_stepover
+    intro >> crawl_tags >> index_extracted_dug_elements >> dummy_stepover
+    dummy_stepover >> validate_index_concepts >> finish

--- a/dags/metadata.yaml
+++ b/dags/metadata.yaml
@@ -72,8 +72,6 @@ kgx:
       - PHAROS_nodes_v3.0.jsonl
       - UberGraph_edges_v3.0.jsonl
       - UberGraph_nodes_v3.0.jsonl
-      - cde/annotated_edges_v3.0.jsonl
-      - cde/annotated_nodes_v3.0.jsonl
     version: v3.0
     name: baseline-graph
     format: jsonl
@@ -81,6 +79,12 @@ kgx:
     files:
     - panther.json
     name: test
+  - version: v3.0
+    name: cde-graph
+    format: jsonl
+    files:
+      - cde/annotated_edges_v3.0.jsonl
+      - cde/annotated_nodes_v3.0.jsonl
 dug_inputs:
   versions:
     - name: bdc

--- a/dags/metadata.yaml
+++ b/dags/metadata.yaml
@@ -72,6 +72,8 @@ kgx:
       - PHAROS_nodes_v3.0.jsonl
       - UberGraph_edges_v3.0.jsonl
       - UberGraph_nodes_v3.0.jsonl
+      - cde/annotated_edges_v3.0.jsonl
+      - cde/annotated_nodes_v3.0.jsonl
     version: v3.0
     name: baseline-graph
     format: jsonl

--- a/dags/roger/config/__init__.py
+++ b/dags/roger/config/__init__.py
@@ -117,7 +117,8 @@ class IndexingConfig(DictLike):
         "anat_to_pheno": ["anatomical_entity", "phenotypic_feature"],
     })
     tranql_endpoint: str = "http://tranql:8081/tranql/query?dynamic_id_resolution=true&asynchronous=false"
-
+    # by default skips node to element queries
+    node_to_element_queries: dict = field(default_factory=lambda: {})
 
 @dataclass
 class ElasticsearchConfig(DictLike):
@@ -178,6 +179,7 @@ class RogerConfig(DictLike):
                 'min_tranql_score': self.indexing.tranql_min_score,
             },
             ontology_greenlist=self.annotation.ontology_greenlist,
+            node_to_element_queries=self.indexing.node_to_element_queries,
         )
 
     @property

--- a/dags/roger/config/__init__.py
+++ b/dags/roger/config/__init__.py
@@ -120,12 +120,21 @@ class IndexingConfig(DictLike):
     # by default skips node to element queries
     node_to_element_queries: dict = field(default_factory=lambda: {})
 
+    def __post_init__(self):
+        node_to_el_enabled = True if self.node_to_element_queries.get("enabled").lower() == "true" else False
+        final_node_to_element_queries = {}
+        if node_to_el_enabled:
+            for key in filter(lambda k: k != "enabled", self.node_to_element_queries.keys()):
+                final_node_to_element_queries[key] = self.node_to_element_queries[key]
+        self.node_to_element_queries = final_node_to_element_queries
+
 @dataclass
 class ElasticsearchConfig(DictLike):
     host: str = "elasticsearch"
     username: str = "elastic"
     password: str = ""
     nboost_host: str = ""
+
 
 
 class RogerConfig(DictLike):

--- a/dags/roger/config/__init__.py
+++ b/dags/roger/config/__init__.py
@@ -121,7 +121,7 @@ class IndexingConfig(DictLike):
     node_to_element_queries: dict = field(default_factory=lambda: {})
 
     def __post_init__(self):
-        node_to_el_enabled = True if self.node_to_element_queries.get("enabled").lower() == "true" else False
+        node_to_el_enabled = True if str(self.node_to_element_queries.get("enabled")).lower() == "true" else False
         final_node_to_element_queries = {}
         if node_to_el_enabled:
             for key in filter(lambda k: k != "enabled", self.node_to_element_queries.keys()):

--- a/dags/roger/config/config.yaml
+++ b/dags/roger/config/config.yaml
@@ -22,7 +22,7 @@ kgx:
     - baseline-graph
 
 dug_inputs:
-  data_source: s3
+  data_source: ""
   dataset_version: v1.0
   data_sets:
     - topmed
@@ -69,6 +69,9 @@ indexing:
     "chemical_mixture_to_disease": ["chemical_mixture", "disease"]
     "phen_to_anat": ["phenotypic_feature", "anatomical_entity"]
   tranql_endpoint: "http://tranql:8081/tranql/query?dynamic_id_resolution=true&asynchronous=false"
+  node_to_element_queries:
+    cde:
+      node_type: biolink:Publication
 
 elasticsearch:
   host: elasticsearch

--- a/dags/roger/config/config.yaml
+++ b/dags/roger/config/config.yaml
@@ -22,7 +22,7 @@ kgx:
     - baseline-graph
 
 dug_inputs:
-  data_source: ""
+  data_source: s3
   dataset_version: v1.0
   data_sets:
     - topmed

--- a/dags/roger/config/config.yaml
+++ b/dags/roger/config/config.yaml
@@ -70,6 +70,7 @@ indexing:
     "phen_to_anat": ["phenotypic_feature", "anatomical_entity"]
   tranql_endpoint: "http://tranql:8081/tranql/query?dynamic_id_resolution=true&asynchronous=false"
   node_to_element_queries:
+    enabled: false
     cde:
       node_type: biolink:Publication
 

--- a/dags/roger/core.py
+++ b/dags/roger/core.py
@@ -851,6 +851,7 @@ class KGXModel:
         # add predicate labels to edges;
         for edge_id in edges:
             edges[edge_id]['predicate_label'] = self.biolink.get_label(edges[edge_id]['predicate'])
+            edges[edge_id]['id'] = edges[edge_id].get('id', edge_id.replace('edge-', ''))
         merge_time = time.time() - merge_time
         current_metric['merge_time'] = merge_time
         write_to_redis_time = time.time()

--- a/dags/roger/core.py
+++ b/dags/roger/core.py
@@ -212,6 +212,11 @@ class Util:
         return sorted(glob.glob(file_pattern))
 
     @staticmethod
+    def dug_extracted_elements_objects():
+        file_pattern = Util.dug_expanded_concepts_path(os.path.join('*', 'extracted_graph_elements.pickle'))
+        return sorted(glob.glob(file_pattern))
+
+    @staticmethod
     def dug_crawl_path(name):
         return str(ROGER_DATA_DIR / 'dug' / 'crawl' / name)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ argcomplete==1.12.0
 apache-airflow==2.1.2
 boto3==1.18.23
 botocore==1.21.23
+black==21.10b0
 flatten-dict
 psycopg2-binary==2.8.6
 redis==3.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ redisgraph-bulk-loader==0.9.5
 requests<2.24.0
 pytest==6.2.2
 PyYAML==5.3.1
-git+git://github.com/helxplatform/dug@2.7.0#egg=dug
+git+git://github.com/helxplatform/dug@release/2.8.0
 elasticsearch==7.11.0
 biolinkml>=1.5.10
 orjson

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ redisgraph-bulk-loader==0.9.5
 requests<2.24.0
 pytest==6.2.2
 PyYAML==5.3.1
-git+git://github.com/helxplatform/dug@release/2.8.0
+git+git://github.com/helxplatform/dug@v2.8.0
 elasticsearch==7.11.0
 biolinkml>=1.5.10
 orjson


### PR DESCRIPTION
- Imports latest dug 
- Adds CDE kgx file to meta-data of kgx and dug inputs
- Adds configuration for concept -> dugelement crawls
- Adds new task in index dag, to crawl for dug elements from graph,
- Makes new task, configured so that it will run only that node_to_elements section is enabled, so we do it by choice in different instances. 
- Recently experiencing heavy slow down on pip resolvers that eventually fails to resolve some of the dependencies (opting for legacy resolver ) till a permanent solution is found