### PR TITLE
Updates to helm charts and corresponding templates

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,9 +1,12 @@
 dependencies:
 - name: airflow
   repository: https://airflow-helm.github.io/charts
-  version: 7.15.0
+  version: 8.6.1
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 12.7.4
-digest: sha256:46d75a6fdcd58a5a57baf09a75918ec3264bfca30b7c065fb4e4f517980168df
-generated: "2021-02-08T12:17:50.2207903-05:00"
+  version: 17.1.2
+- name: elasticsearch
+  repository: https://helm.elastic.co
+  version: 7.16.3
+digest: sha256:8c3706ca6b195236f3017cd98ad2632193c92f4b319692f47d64a5f0425ea41a
+generated: "2023-01-16T13:38:22.15342-05:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -25,11 +25,11 @@ appVersion: 1.0.0
 # Dependencies that roger requires
 dependencies:
   - name: airflow
-    version: "v7.15.0"
+    version: "v8.6.1"
     repository: "https://airflow-helm.github.io/charts"
   - name: redis
-    version: "12.7.4"
+    version: "17.1.2"
     repository: "https://charts.bitnami.com/bitnami"
   - name: elasticsearch
-    version: "7.12.0"
+    version: "7.16.3"
     repository: "https://helm.elastic.co"


### PR DESCRIPTION
 - replacing deprecated apiVersion for poddisruptionbudget with correct version v1